### PR TITLE
libbpf.c: customize bpf_object__probe_loading()

### DIFF
--- a/src/libbpf.c
+++ b/src/libbpf.c
@@ -3725,7 +3725,8 @@ bpf_object__probe_loading(struct bpf_object *obj)
 	/* make sure basic loading works */
 
 	memset(&attr, 0, sizeof(attr));
-	attr.prog_type = BPF_PROG_TYPE_SOCKET_FILTER;
+//	attr.prog_type = BPF_PROG_TYPE_SOCKET_FILTER;
+	attr.prog_type = BPF_PROG_TYPE_TRACEPOINT;
 	attr.insns = insns;
 	attr.insns_cnt = ARRAY_SIZE(insns);
 	attr.license = "GPL";


### PR DESCRIPTION
when running helloworld_ex2 on CentOS 7.7, it fails with:
  libbpf: Error in bpf_object__probe_loading():Invalid argument(22).
  Couldn't load trivial BPF program. Make sure your kernel supports BPF
  (CONFIG_BPF_SYSCALL=y) and/or that RLIMIT_MEMLOCK is set to big enough
  value.
  libbpf: failed to load object './helloworld_ex2_kern.o'
  ERROR: bpf_prog_load() failed

and dmesg shows:
  [ 1464.934844] TECH PREVIEW: eBPF syscall may not be fully supported.

So, turns out, that in RHEL/CentOS back-ported eBPF functionality isn't
fully supported!
Specifically, when libbpf::bpf_object__probe_loading() trying to probe
using bpf_prog_type of 'BPF_PROG_TYPE_SOCKET_FILTER' which isn't
supported.

Thus, as an workaround, overrding 'BPF_PROG_TYPE_SOCKET_FILTER'
with 'BPF_PROG_TYPE_TRACEPOINT' supported type.