### PR TITLE
libbpf customizations

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -28,6 +28,7 @@ ifdef NO_PKG_CONFIG
 else
 	PKG_CONFIG ?= pkg-config
 	ALL_CFLAGS += $(shell $(PKG_CONFIG) --cflags libelf zlib)
+	ALL_CFLAGS += $(shell $(PKG_CONFIG) --cflags libelf)/..
 	ALL_LDFLAGS += $(shell $(PKG_CONFIG) --libs libelf zlib)
 endif
 

--- a/src/libbpf.c
+++ b/src/libbpf.c
@@ -55,6 +55,12 @@
 #include "libbpf_internal.h"
 #include "hashmap.h"
 
+// Customization:
+// was fmemopen@GLIBC_2.2.22,
+// enforce symbol version as linux agent works with GLIBC_2.19
+// refer to fmemopen(3)
+__asm__(".symver fmemopen,fmemopen@GLIBC_2.2.5");
+
 #ifndef EM_BPF
 #define EM_BPF 247
 #endif

--- a/src/libbpf.h
+++ b/src/libbpf.h
@@ -759,6 +759,34 @@ enum libbpf_tristate {
 	TRI_MODULE = 2,
 };
 
+// Customization:
+/*
+ * libbpf does all kinds of probing as part of its flow.
+ *
+ * This function configures the prog_type used by
+ * relevant *probe_* functions.
+ *
+ * This way, if eBPF program uses a specific bpf_prog_type,
+ * it's possible to configure libbpf *probe_* functions to use SAME type.
+ *
+ * Thus, extends libbpf portability, as on old kernels/distros
+ * not all bpf_prog_types are supported and using unexpected bpf_prog_type
+ * might result in bpf syscall error, failing the whole program.
+ *
+ * IMPORTANT:
+ *   - call this function at most ONCE in your program
+ *     and BEFORE using libbpf API
+ */
+LIBBPF_API bool bpf_set_once_probe_prog_type(enum bpf_prog_type type);
+
+// Customization:
+/*
+ *  if 'bpf_set_once_probe_prog_type' was called before,
+ *  this function will return the pre-configured type,
+ *  otherwise, given 'default_type' is returned
+ */
+LIBBPF_API enum bpf_prog_type bpf_get_probe_prog_type(enum bpf_prog_type default_type);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif


### PR DESCRIPTION
linuxagent_ng is being built using GLIBC_2.19,
thus need to ensure glibc symbol versions are as expected.

NOTE: a useful explanation can be found at:
https://stackoverflow.com/questions/4032373/linking-against-an-old-version-of-libc-to-provide-greater-application-coverage

main guidelines:
1. 'objdump -p <object>'
   to see current GLIBC symbol versions, addresses resolution
2. 'objdump -T <object> | grep -F GLIBC_<target version>'
   to get symbol name
3. 'objdump -T <path to libc.so.6>/libc.so.6 | grep -w <symbol name>
4. if u lucky, <symbol name> exist also in different GLIBC versions
5. adjust source code, use __asm__(".symver...") to choose specific version for the symbol
6. rebuild and verify symbol's GLIBC vesrion is as expected