### PR TITLE
libbpf/include: adjust inclusion guards

### DIFF
--- a/include/linux/err.h
+++ b/include/linux/err.h
@@ -1,7 +1,10 @@
 /* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
 
-#ifndef __LINUX_ERR_H
+#if !defined(__LINUX_ERR_H) && !defined(_LINUX_ERR_H) || !defined(_UAPI__LINUX_ERR_H)
+
 #define __LINUX_ERR_H
+#define _LINUX_ERR_H
+#define _UAPI__LINUX_ERR_H
 
 #include <linux/types.h>
 #include <asm/errno.h>

--- a/include/linux/types.h
+++ b/include/linux/types.h
@@ -1,7 +1,10 @@
 /* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
 
-#ifndef __LINUX_TYPES_H
+#if !defined(__LINUX_TYPES_H) && !defined(_LINUX_TYPES_H) || !defined(_UAPI__LINUX_TYPES_H)
+
 #define __LINUX_TYPES_H
+#define _LINUX_TYPES_H
+#define _UAPI__LINUX_TYPES_H
 
 #include <stdbool.h>
 #include <stddef.h>

--- a/include/uapi/linux/bpf.h
+++ b/include/uapi/linux/bpf.h
@@ -5,7 +5,10 @@
  * modify it under the terms of version 2 of the GNU General Public
  * License as published by the Free Software Foundation.
  */
-#ifndef _UAPI__LINUX_BPF_H__
+#if !defined(__LINUX_BPF_H__) && !defined(_LINUX_BPF_H__) || !defined(_UAPI__LINUX_BPF_H__)
+
+#define __LINUX_BPF_H__
+#define _LINUX_BPF_H__
 #define _UAPI__LINUX_BPF_H__
 
 #include <linux/types.h>
@@ -5151,4 +5154,4 @@ enum {
 	BTF_F_ZERO	=	(1ULL << 3),
 };
 
-#endif /* _UAPI__LINUX_BPF_H__ */
+#endif

--- a/include/uapi/linux/bpf_common.h
+++ b/include/uapi/linux/bpf_common.h
@@ -1,5 +1,9 @@
 /* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
-#ifndef _UAPI__LINUX_BPF_COMMON_H__
+
+#if !defined(__LINUX_BPF_COMMON_H__) && !defined(_LINUX_BPF_COMMON_H__) || !defined(_UAPI__LINUX_BPF_COMMON_H__)
+
+#define __LINUX_BPF_COMMON_H__
+#define _LINUX_BPF_COMMON_H__
 #define _UAPI__LINUX_BPF_COMMON_H__
 
 /* Instruction classes */
@@ -54,4 +58,4 @@
 #define BPF_MAXINSNS 4096
 #endif
 
-#endif /* _UAPI__LINUX_BPF_COMMON_H__ */
+#endif


### PR DESCRIPTION
When trying to compile with libbpf as dependency, libbpf/include files
also exposed to other compilation units. Means, instead of taking
machine included files (for example, from /usr/include/linux'),
it will use libbpf/include headers.
This can break build or worse, cause hard to detect bugs etc.

Thus extending the inclusion guard definition, to cover differnt formats
and hopefully prevent above scenario.

For now, deploying this solution for files that are exposed by libbpf.h, bpf.h
headers.